### PR TITLE
warp: Replace blaze-builder with bsb-http-chunked

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,7 @@ flags:
   wai-extra:
     build-example: true
 extra-deps:
+- bsb-http-chunked-0
 - tls-session-manager-0.0.0.2
 - psqueues-0.2.4.0
 - streaming-commons-0.2.0.0

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -91,7 +91,6 @@ import qualified Data.ByteString.Lazy.Internal as LI
 import           Data.ByteString.Lazy.Internal (defaultChunkSize)
 import           Data.ByteString.Lazy.Char8   ()
 import           Data.Function                (fix)
-import           Data.Monoid                  (mempty)
 import qualified Network.HTTP.Types           as H
 import           Network.Socket               (SockAddr (SockAddrInet))
 import           Network.Wai.Internal

--- a/wai/test/Network/WaiSpec.hs
+++ b/wai/test/Network/WaiSpec.hs
@@ -4,7 +4,6 @@ import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
 import Network.Wai
 import Data.IORef
-import Data.Monoid
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import Data.ByteString.Builder (Builder, toLazyByteString, word8)

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -2,7 +2,8 @@ Name:                wai
 Version:             3.2.1.2
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
-description:         API docs and the README are available at <http://www.stackage.org/package/wai>.
+                     .
+                     API docs and the README are available at <http://www.stackage.org/package/wai>.
 License:             MIT
 License-file:        LICENSE
 Author:              Michael Snoyman

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -41,6 +41,7 @@ test-suite test
                   , hspec
                   , bytestring
     other-modules:  Network.WaiSpec
+    build-tool-depends: hspec-discover:hspec-discover
 
 source-repository head
   type:     git

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.2.18.2
+
+* Replace dependency on `blaze-builder` with `bsb-http-chunked` [#683](https://github.com/yesodweb/wai/pull/683)
+
 ## 3.2.18.1
 
 * Fix benchmark compilation [#681](https://github.com/yesodweb/wai/issues/681)

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,6 +1,6 @@
 ## 3.2.18.2
 
-* Replace dependency on `blaze-builder` with `bsb-http-chunked` [#683](https://github.com/yesodweb/wai/pull/683)
+* Replace dependency on `blaze-builder` with `bsb-http-chunked`
 
 ## 3.2.18.1
 

--- a/warp/Network/Wai/Handler/Warp/MultiMap.hs
+++ b/warp/Network/Wai/Handler/Warp/MultiMap.hs
@@ -15,6 +15,7 @@ import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as I
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup
+import Prelude -- Silence redundant import warnings
 
 import Network.Wai.Handler.Warp.Imports hiding ((<>), union, empty, insert)
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -13,7 +13,7 @@ module Network.Wai.Handler.Warp.Response (
   , addServer -- testing
   ) where
 
-import Blaze.ByteString.Builder.HTTP (chunkedTransferEncoding, chunkedTransferTerminator)
+import Data.ByteString.Builder.HTTP.Chunked (chunkedTransferEncoding, chunkedTransferTerminator)
 import qualified Control.Exception as E
 import Data.Array ((!))
 import qualified Data.ByteString as S

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.2.18.1
+Version:             3.2.18.2
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE
@@ -37,7 +37,7 @@ Library
                    , array
                    , async
                    , auto-update               >= 0.1.3    && < 0.2
-                   , blaze-builder             >= 0.4
+                   , bsb-http-chunked                         < 0.1
                    , bytestring                >= 0.9.1.4
                    , case-insensitive          >= 0.2
                    , containers
@@ -181,7 +181,7 @@ Test-Suite spec
     Build-Depends:   base >= 4.8 && < 5
                    , array
                    , auto-update
-                   , blaze-builder             >= 0.4
+                   , bsb-http-chunked                         < 0.1
                    , bytestring                >= 0.9.1.4
                    , case-insensitive          >= 0.2
                    , ghc-prim
@@ -211,6 +211,7 @@ Test-Suite spec
                    , word8
                    , hashable
                    , http-date
+    Build-Tool-Depends: hspec-discover:hspec-discover
   if impl(ghc < 8)
       Build-Depends: semigroups
 


### PR DESCRIPTION
This is for inclusion in https://github.com/yesodweb/wai/pull/682.

(I had also done some work on wai, most of which is redundant)